### PR TITLE
Enable shared library builds on Cygwin

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,4 @@ stamp-h1
 cliquer-*.tar.gz
 src/cl
 test/testcases
+INSTALL

--- a/lib/Makefile.am
+++ b/lib/Makefile.am
@@ -1,4 +1,4 @@
 lib_LTLIBRARIES = libcliquer.la
 libcliquer_la_SOURCES = cliquer.c graph.c reorder.c
 libcliquer_la_CPPFLAGS = -I$(top_srcdir)/include
-libcliquer_la_LDFLAGS = @LIBS@ -version-info @LT_CURRENT@:@LT_REVISION@:@LT_AGE@
+libcliquer_la_LDFLAGS = @LIBS@ -version-info @LT_CURRENT@:@LT_REVISION@:@LT_AGE@ -no-undefined

--- a/test/Makefile.am
+++ b/test/Makefile.am
@@ -1,4 +1,8 @@
 TESTS = testcases
+
+LOG_COMPILER = $(abs_srcdir)/testcases_wrapper.sh
+EXTRA_DIST = testcases_wrapper.sh
+
 check_HEADERS = testcase-large-exact8.h testcase-large-w-60-64-mxml.h testcase-large-over8.h testcase-large-w-over60.h
 check_PROGRAMS = testcases
 dist_pkgdata_DATA = testcase-large.b  testcase-large-w.b  testcase-small.a

--- a/test/testcases_wrapper.sh
+++ b/test/testcases_wrapper.sh
@@ -1,0 +1,3 @@
+#! /bin/sh
+abs_builddir=$(pwd)
+cd ${srcdir} && ${abs_builddir}/testcases


### PR DESCRIPTION
Fixes #4 