### PR TITLE
fix code related to <sys/times.h> on MSYS2 / MINGW64

### DIFF
--- a/lib/reorder.c
+++ b/lib/reorder.c
@@ -9,7 +9,9 @@
 #include "cliquer/reorder.h"
 
 #include <time.h>
+#if !defined(__MINGW64__)
 #include <sys/times.h>
+#endif
 #include <stdlib.h>
 
 #include <limits.h>
@@ -406,12 +408,18 @@ int *reorder_by_degree(graph_t *g, boolean weighted) {
  *       is called using the system time.
  */
 int *reorder_by_random(graph_t *g, boolean weighted) {
+#if !defined(__MINGW64__)
 	struct tms t;
+#endif
 	int i,r;
 	int *new;
 	boolean *used;
 
+#if !defined(__MINGW64__)
 	srand(times(&t)+time(NULL));
+#else
+	srand(time(NULL));
+#endif
 
 	new=calloc(g->n, sizeof(int));
 	used=calloc(g->n, sizeof(boolean));


### PR DESCRIPTION
This removes references to `<sys/times.h>` and its functions, but only on MSYS2 / MINGW64, because `<sys/times.h>` is not available there. That way cliquer can be built for MSYS2 / MINGW64.

The original patch is by Pranav Rajpal, taken from passagemath, <https://github.com/passagemath/passagemath/commit/a90633c0c1cf7637abf04ad9030bcd626a1f32c1>, but slightly modified. Instead of removing the code using the `<sys/times.h>` header it guards those parts by pre-processor directives, effectively disabling it for MSYS2 / MINGW64 and leaving it unchanged for others.


A variation of that patch is currently used to build the MSYS2 package for cliquer / autocliquer: https://github.com/msys2/MINGW-packages/tree/19d8adde83feb2865712822ba4de766767c9fd31/mingw-w64-cliquer