### PR TITLE
add CI job for Windows build with MSYS2

### DIFF
--- a/.github/workflows/c-cpp.yml
+++ b/.github/workflows/c-cpp.yml
@@ -12,11 +12,35 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v6
     -  name: autotools
        run: autoreconf -ivf
     - name: configure
       run: ./configure
+    - name: make
+      run: make
+    - name: make check
+      run: make check
+
+  build-windows:
+    runs-on: windows-latest
+    defaults:
+      run:
+        shell: msys2 {0}
+    steps:
+    - uses: actions/checkout@v6
+    - name: Setup MSYS2 and install toolchain
+      uses: msys2/setup-msys2@v2
+      with:
+        msystem: mingw64
+        update: true
+        install: >-
+          mingw-w64-x86_64-autotools
+          mingw-w64-x86_64-cc
+    - name: autotools
+      run: autoreconf -ivf
+    - name: configure
+      run: ./configure --prefix="${MINGW_PREFIX}"
     - name: make
       run: make
     - name: make check


### PR DESCRIPTION
Now that the MinGW64 patch in <https://github.com/dimpase/autocliquer/pull/8> has been merged a CI build on Windows is possible.

After the installation of MSYS2 and the toolchain (autotools + GCC) the steps are basically the same as on Linux.